### PR TITLE
Refactor environment variable handling to use process.env instead of react-native-dotenv

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -12,6 +12,6 @@ module.exports = function (api) {
 
   return {
     presets: ["babel-preset-expo"],
-    plugins: ["module:react-native-dotenv"],
+    plugins,
   };
 };

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "eslint": "^8.57.0",
     "eslint-config-universe": "^12.0.1",
     "prettier": "^3.2.5",
-    "react-native-dotenv": "^3.4.11",
     "typescript": "~5.3.3"
   },
   "eslintConfig": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,9 +123,6 @@ importers:
       prettier:
         specifier: ^3.2.5
         version: 3.5.3
-      react-native-dotenv:
-        specifier: ^3.4.11
-        version: 3.4.11(@babel/runtime@7.26.10)
       typescript:
         specifier: ~5.3.3
         version: 5.3.3
@@ -4600,11 +4597,6 @@ packages:
 
   react-is@18.3.1:
     resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
-
-  react-native-dotenv@3.4.11:
-    resolution: {integrity: sha512-6vnIE+WHABSeHCaYP6l3O1BOEhWxKH6nHAdV7n/wKn/sciZ64zPPp2NUdEUf1m7g4uuzlLbjgr+6uDt89q2DOg==}
-    peerDependencies:
-      '@babel/runtime': ^7.20.6
 
   react-native-gesture-handler@2.20.2:
     resolution: {integrity: sha512-HqzFpFczV4qCnwKlvSAvpzEXisL+Z9fsR08YV5LfJDkzuArMhBu2sOoSPUF/K62PCoAb+ObGlTC83TKHfUd0vg==}
@@ -11563,11 +11555,6 @@ snapshots:
   react-is@16.13.1: {}
 
   react-is@18.3.1: {}
-
-  react-native-dotenv@3.4.11(@babel/runtime@7.26.10):
-    dependencies:
-      '@babel/runtime': 7.26.10
-      dotenv: 16.4.7
 
   react-native-gesture-handler@2.20.2(react-native@0.76.7(@babel/core@7.26.10)(@babel/preset-env@7.26.9(@babel/core@7.26.10))(@types/react@18.3.18)(react@18.3.1))(react@18.3.1):
     dependencies:

--- a/utils/supabase.ts
+++ b/utils/supabase.ts
@@ -1,8 +1,7 @@
-import { EXPO_PUBLIC_SUPABASE_URL, EXPO_PUBLIC_SUPABASE_ANON_KEY } from "@env";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { createClient } from "@supabase/supabase-js";
-const supabaseUrl = EXPO_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = EXPO_PUBLIC_SUPABASE_ANON_KEY;
+const supabaseUrl = process.env.EXPO_PUBLIC_SUPABASE_URL;
+const supabaseAnonKey = process.env.EXPO_PUBLIC_SUPABASE_ANON_KEY;
 
 // Check if the environment variables are set
 if (!supabaseUrl || !supabaseAnonKey) {


### PR DESCRIPTION
Refactors env var handling

Removes react-native-dotenv from Babel config and dependencies.
Updates supabase client initialization to use process.env for environment variables.