### PR TITLE
bump version

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Skanida Apps",
     "slug": "skanida-apps-mobile",
-    "version": "1.8.1-internaldev",
+    "version": "1.8.2-internaldev",
     "scheme": "skanida-apps-mobile",
     "web": {
       "bundler": "metro",

--- a/app/Dashboard.tsx
+++ b/app/Dashboard.tsx
@@ -673,7 +673,7 @@ export default function Dashboard() {
         {/* --- Footer Section --- */}
         <View className="items-center px-6 py-3 border-t border-border bg-background">
           <Text variant="small" className="font-bold text-foreground">
-            v1.8.1-internaldev | Branch: develop
+            v1.8.2-internaldev | Branch: develop
           </Text>
         </View>
       </SafeAreaView>

--- a/app/extra/pengaturan.tsx
+++ b/app/extra/pengaturan.tsx
@@ -453,7 +453,7 @@ function Pengaturan() {
                 <Text variant="small" className="font-medium">
                   Versi Aplikasi
                 </Text>
-                <Text variant="default">Version 1.8.1-internaldev</Text>
+                <Text variant="default">Version 1.8.2-internaldev</Text>
               </View>
 
               <View className="pt-3 border-t border-border">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "skanida-apps-mobile",
-  "version": "1.8.1-internaldev",
+  "version": "1.8.2-internaldev",
   "main": "expo-router/entry",
   "scripts": {
     "android": "expo run:android",


### PR DESCRIPTION
This pull request updates the application version from `1.8.1-internaldev` to `1.8.2-internaldev` across the codebase to ensure consistency and reflect the latest internal development build.

Version bump across the project:

* Updated the `version` field in `app.json` to `1.8.2-internaldev` to reflect the new internal development version.
* Changed the displayed version in the dashboard footer (`app/Dashboard.tsx`) to `v1.8.2-internaldev`.
* Updated the application version text in the settings screen (`app/extra/pengaturan.tsx`) to `Version 1.8.2-internaldev`.
* Bumped the `version` field in `package.json` to `1.8.2-internaldev` for package management consistency.